### PR TITLE
revert testnet token list

### DIFF
--- a/jsons/testnet/evm/default.json
+++ b/jsons/testnet/evm/default.json
@@ -1,227 +1,37 @@
 {
-  "name": "Flow Token List",
-  "network": "testnet",
-  "chainId": 545,
-  "tokens": [
-    {
-      "chainId": 545,
-      "address": "0x3c9469d8c179c35c9b908ca46a8670a419628f0a",
-      "contractName": "EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0a",
-      "path": {
-        "vault": "/storage/EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0aVault",
-        "receiver": "/public/EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0aReceiver",
-        "balance": "/public/EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0aVault"
-      },
-      "evmAddress": "0x3c9469d8c179c35c9b908ca46a8670a419628f0a",
-      "flowAddress": "0xdfc20aee650fcbdf",
-      "symbol": "USDC",
-      "name": "USDC",
-      "description": "This fungible token was bridged from EVM on Flow with the ERC20 contract address of 3c9469d8c179c35c9b908ca46a8670a419628f0a",
-      "decimals": 6,
-      "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.b19436aae4d94622.FiatToken/logo.png",
-      "tags": [],
-      "extensions": {
-        "website": "https://port.flow.com",
-        "displaySource": "0xa51d7fe9e0080662"
-      },
-      "flowIdentifier": "A.dfc20aee650fcbdf.EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0a.Vault",
-      "website": "https://evm.flowscan.io/token/0x3c9469d8c179c35c9b908ca46a8670a419628f0a"
-    },
-    {
-      "chainId": 545,
-      "address": "0x5b67057fa946a4a664546e3df9d2d1b1ab222f36",
-      "contractName": "EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36",
-      "path": {
-        "vault": "/storage/EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36Vault",
-        "receiver": "/public/EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36Receiver",
-        "balance": "/public/EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36Vault"
-      },
-      "evmAddress": "0x5b67057fa946a4a664546e3df9d2d1b1ab222f36",
-      "flowAddress": "0xdfc20aee650fcbdf",
-      "symbol": "USDT",
-      "name": "USDT",
-      "description": "This fungible token was bridged from EVM on Flow with the ERC20 contract address of 5b67057fa946a4a664546e3df9d2d1b1ab222f36",
-      "decimals": 6,
-      "logoURI": "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg",
-      "tags": [],
-      "extensions": {
-        "website": "https://port.flow.com"
-      },
-      "flowIdentifier": "A.dfc20aee650fcbdf.EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36.Vault",
-      "website": "https://evm.flowscan.io/token/0x5b67057fa946a4a664546e3df9d2d1b1ab222f36"
-    },
-    {
-      "chainId": 545,
-      "address": "0x6ef85d7fe35bc78e10d9b0e9eddc1728b7309cb5",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x0b3677727d6e6240TBH_Vault",
-        "receiver": "/public/FixsStandardFT_0x0b3677727d6e6240TBH_Receiver",
-        "balance": "/public/FixsStandardFT_0x0b3677727d6e6240TBH_Balance"
-      },
-      "evmAddress": "0x6ef85d7fe35bc78e10d9b0e9eddc1728b7309cb5",
-      "flowAddress": "0x0b3677727d6e6240",
-      "symbol": "TBH",
-      "name": "Bohao Token",
-      "description": "No description",
-      "decimals": 18,
-      "logoURI": "https://static.fixes.world/12SEVBRC5qcG1719913990511",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      },
-      "flowIdentifier": "A.0b3677727d6e6240.FixesFungibleToken.Vault",
-      "website": "https://evm.flowscan.io/token/0x6ef85d7fe35bc78e10d9b0e9eddc1728b7309cb5"
-    },
-    {
-      "chainId": 545,
-      "address": "0x8a4ab4d698466da964f51d0b2bb2868f08f595ce",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0xdf150e8513135e4fTBHD_Vault",
-        "receiver": "/public/FixsStandardFT_0xdf150e8513135e4fTBHD_Receiver",
-        "balance": "/public/FixsStandardFT_0xdf150e8513135e4fTBHD_Balance"
-      },
-      "evmAddress": "0x8a4ab4d698466da964f51d0b2bb2868f08f595ce",
-      "flowAddress": "0xdf150e8513135e4f",
-      "symbol": "TBHD",
-      "name": "Bohao D",
-      "description": "No description",
-      "decimals": 18,
-      "logoURI": "https://static.fixes.world/12SEVBRC5qcG1721379209087",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      },
-      "flowIdentifier": "A.df150e8513135e4f.FixesFungibleToken.Vault",
-      "website": "https://evm.flowscan.io/token/0x8a4ab4d698466da964f51d0b2bb2868f08f595ce"
-    },
-    {
-      "chainId": 545,
-      "address": "0x75c76ed2b25560ab04fda05a255c5fcc8937dd56",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x625f49193dcdccfcTBH_Vault",
-        "receiver": "/public/FixsStandardFT_0x625f49193dcdccfcTBH_Receiver",
-        "balance": "/public/FixsStandardFT_0x625f49193dcdccfcTBH_Balance"
-      },
-      "evmAddress": "0x75c76ed2b25560ab04fda05a255c5fcc8937dd56",
-      "flowAddress": "0x625f49193dcdccfc",
-      "symbol": "TBH",
-      "name": "Bohao Token",
-      "description": "Hello World",
-      "decimals": 18,
-      "logoURI": "http://static.fixes.world/12SEVBRC5qcG1719414852854",
-      "tags": [],
-      "extensions": {
-        "telegram": "https://t.me/bt_wood",
-        "twitter": "https://x.com/btspoony",
-        "github": "https://github.com/btspoony",
-        "website": "https://btang.cn/"
-      },
-      "flowIdentifier": "A.625f49193dcdccfc.FixesFungibleToken.Vault",
-      "website": "https://evm.flowscan.io/token/0x75c76ed2b25560ab04fda05a255c5fcc8937dd56"
-    },
-    {
-      "chainId": 545,
-      "address": "0x6db6751d287a3a0dacec6be6da3e3cfba1f52c5f",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0xe8485c7c2a6e7984TBHCB_Vault",
-        "receiver": "/public/FixsStandardFT_0xe8485c7c2a6e7984TBHCB_Receiver",
-        "balance": "/public/FixsStandardFT_0xe8485c7c2a6e7984TBHCB_Balance"
-      },
-      "evmAddress": "0x6db6751d287a3a0dacec6be6da3e3cfba1f52c5f",
-      "flowAddress": "0xe8485c7c2a6e7984",
-      "symbol": "TBHCB",
-      "name": "Bohao Token CB",
-      "description": "No description",
-      "decimals": 18,
-      "logoURI": "https://static.fixes.world/20SGVhZENpcm1721970005207",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      },
-      "flowIdentifier": "A.e8485c7c2a6e7984.FixesFungibleToken.Vault",
-      "website": "https://evm.flowscan.io/token/0x6db6751d287a3a0dacec6be6da3e3cfba1f52c5f"
-    },
-    {
-      "chainId": 545,
-      "address": "0xd3bf53dac106a0290b0483ecbc89d40fcc961f3e",
-      "contractName": "FlowToken",
-      "path": {
-        "vault": "/storage/flowTokenVault",
-        "receiver": "/public/flowTokenReceiver",
-        "balance": "/public/flowTokenBalance"
-      },
-      "evmAddress": "0xd3bf53dac106a0290b0483ecbc89d40fcc961f3e",
-      "flowAddress": "0x7e60df042a9c0868",
-      "symbol": "FLOW",
-      "name": "Flow",
-      "description": "",
-      "decimals": 18,
-      "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.1654653399040a61.FlowToken/logo.svg",
-      "tags": [
-        "utility-token"
-      ],
-      "extensions": {
-        "documentation": "https://developers.flow.com/build/core-contracts/flow-token",
-        "coingeckoId": "flow",
-        "github": "https://github.com/onflow/flow-core-contracts",
-        "discord": "https://discord.com/invite/J6fFnh2xx6",
-        "twitter": "https://twitter.com/flow_blockchain",
-        "website": "https://flow.com",
-        "displaySource": "0xa51d7fe9e0080662",
-        "pathSource": "0xa51d7fe9e0080662"
-      },
-      "flowIdentifier": "A.7e60df042a9c0868.FlowToken.Vault",
-      "website": "https://evm.flowscan.io/token/0xd3bf53dac106a0290b0483ecbc89d40fcc961f3e"
-    }
-  ],
-  "totalAmount": 7,
-  "filterType": "ALL",
-  "timestamp": "2024-12-22T01:22:26.374Z",
-  "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.1654653399040a61.FlowToken/logo.svg",
+  "name": "Flow testnet EVM FT List",
+  "logoURI": "",
   "keywords": [
-    "Flow",
-    "Cadence",
-    "EVM",
-    "DeFi",
-    "NFT",
-    "FT",
-    "Dapp",
-    "Blockchain",
-    "Crypto"
+    "testnet",
+    "FTs"
   ],
   "tags": {
     "stablecoin": {
-      "name": "stablecoin",
+      "name": "Stablecoin",
       "description": "Tokens that are fixed to an external asset, e.g. the US dollar"
-    },
-    "ethereum": {
-      "name": "ethereum",
-      "description": "Asset bridged from ethereum"
-    },
-    "wrapped-celer": {
-      "name": "wrapped-celer",
-      "description": "Asset wrapped using celer bridge"
-    },
-    "utility-token": {
-      "name": "utility-token",
-      "description": "Tokens that are designed to be spent within a certain blockchain ecosystem"
-    },
-    "governance-token": {
-      "name": "governance-token",
-      "description": "Tokens that are designed to be use in community governance and maintenance"
-    },
-    "memecoin": {
-      "name": "memecoin",
-      "description": "Tokens that are created for fun and meme"
     }
   },
-  "version": {
-    "major": 1,
-    "minor": 0,
-    "patch": 4
-  }
+  "timestamp": "",
+  "tokens": [
+    {
+      "chainId": 545,
+      "address": "0x01f4F81F57da8bC8F1005cF800aFdD4A2EfbF5f5",
+      "symbol": "MTK",
+      "name": "MyToken",
+      "decimals": 18,
+      "logoURI": "",
+      "tags": []
+    },
+    {
+      "chainId": 545,
+      "address": "0xd50DCCA32B76dBf180cc5Dd7eFD2e6E0a545Ba3a",
+      "symbol": "EFT",
+      "name": "Example Fungible Token",
+      "decimals": 18,
+      "logoURI": "",
+      "flowIdentifier": "A.390b4705da6305c3.ExampleToken.Vault",
+      "tags": []
+    }
+  ],
+  "totalAmount": 2
 }

--- a/jsons/testnet/flow/default.json
+++ b/jsons/testnet/flow/default.json
@@ -5,293 +5,47 @@
   "tokens": [
     {
       "chainId": 545,
-      "address": "0xdfc20aee650fcbdf",
-      "contractName": "EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0a",
+      "address": "0xa983fecbed621163",
+      "contractName": "FiatToken",
       "path": {
-        "vault": "/storage/EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0aVault",
-        "receiver": "/public/EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0aReceiver",
-        "balance": "/public/EVMVMBridgedToken_3c9469d8c179c35c9b908ca46a8670a419628f0aVault"
+        "vault": "/storage/USDCVault",
+        "receiver": "/public/USDCVaultReceiver",
+        "balance": "/public/USDCVaultBalance"
       },
-      "evmAddress": "0x3c9469d8c179c35c9b908ca46a8670a419628f0a",
-      "flowAddress": "0xdfc20aee650fcbdf",
       "symbol": "USDC",
-      "name": "USDC",
-      "description": "This fungible token was bridged from EVM on Flow with the ERC20 contract address of 3c9469d8c179c35c9b908ca46a8670a419628f0a",
-      "decimals": 6,
-      "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.b19436aae4d94622.FiatToken/logo.png",
-      "tags": [],
-      "extensions": {
-        "website": "https://port.flow.com",
-        "displaySource": "0xa51d7fe9e0080662"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0xdfc20aee650fcbdf",
-      "contractName": "EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36",
-      "path": {
-        "vault": "/storage/EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36Vault",
-        "receiver": "/public/EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36Receiver",
-        "balance": "/public/EVMVMBridgedToken_5b67057fa946a4a664546e3df9d2d1b1ab222f36Vault"
-      },
-      "evmAddress": "0x5b67057fa946a4a664546e3df9d2d1b1ab222f36",
-      "flowAddress": "0xdfc20aee650fcbdf",
-      "symbol": "USDT",
-      "name": "USDT",
-      "description": "This fungible token was bridged from EVM on Flow with the ERC20 contract address of 5b67057fa946a4a664546e3df9d2d1b1ab222f36",
-      "decimals": 6,
-      "logoURI": "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg",
-      "tags": [],
-      "extensions": {
-        "website": "https://port.flow.com"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0xe8485c7c2a6e7984",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0xe8485c7c2a6e7984TBHCB_Vault",
-        "receiver": "/public/FixsStandardFT_0xe8485c7c2a6e7984TBHCB_Receiver",
-        "balance": "/public/FixsStandardFT_0xe8485c7c2a6e7984TBHCB_Balance"
-      },
-      "evmAddress": "0x6db6751d287a3a0dacec6be6da3e3cfba1f52c5f",
-      "flowAddress": "0xe8485c7c2a6e7984",
-      "symbol": "TBHCB",
-      "name": "Bohao Token CB",
-      "description": "No description",
+      "name": "USD Coin",
+      "description": "",
       "decimals": 8,
-      "logoURI": "https://static.fixes.world/20SGVhZENpcm1721970005207",
+      "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.b19436aae4d94622.FiatToken/logo.svg",
       "tags": [],
       "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
+        "coingeckoId": "usd-coin",
+        "documentation": "https://developers.circle.com/stablecoins/docs",
+        "twitter": "https://twitter.com/circle",
+        "website": "https://www.circle.com/en/usdc-multichain/flow",
+        "displaySource": "0xa51d7fe9e0080662",
+        "pathSource": "0xa51d7fe9e0080662"
       }
     },
     {
       "chainId": 545,
-      "address": "0xdf150e8513135e4f",
-      "contractName": "FixesFungibleToken",
+      "address": "0x9392a4a7c3f49a0b",
+      "contractName": "FlovatarDustToken",
       "path": {
-        "vault": "/storage/FixsStandardFT_0xdf150e8513135e4fTBHD_Vault",
-        "receiver": "/public/FixsStandardFT_0xdf150e8513135e4fTBHD_Receiver",
-        "balance": "/public/FixsStandardFT_0xdf150e8513135e4fTBHD_Balance"
+        "vault": "/storage/FlovatarDustTokenVault",
+        "receiver": "/public/FlovatarDustTokenReceiver",
+        "balance": "/public/FlovatarDustTokenBalance"
       },
-      "evmAddress": "0x8a4ab4d698466da964f51d0b2bb2868f08f595ce",
-      "flowAddress": "0xdf150e8513135e4f",
-      "symbol": "TBHD",
-      "name": "Bohao D",
-      "description": "No description",
+      "symbol": "DUST",
+      "name": "Flovatar DUST",
+      "description": "",
       "decimals": 8,
-      "logoURI": "https://static.fixes.world/12SEVBRC5qcG1721379209087",
+      "logoURI": "http://images.flovatar.com/logo-round.png",
       "tags": [],
       "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0x625f49193dcdccfc",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x625f49193dcdccfcTBH_Vault",
-        "receiver": "/public/FixsStandardFT_0x625f49193dcdccfcTBH_Receiver",
-        "balance": "/public/FixsStandardFT_0x625f49193dcdccfcTBH_Balance"
-      },
-      "evmAddress": "0x75c76ed2b25560ab04fda05a255c5fcc8937dd56",
-      "flowAddress": "0x625f49193dcdccfc",
-      "symbol": "TBH",
-      "name": "Bohao Token",
-      "description": "Hello World",
-      "decimals": 8,
-      "logoURI": "http://static.fixes.world/12SEVBRC5qcG1719414852854",
-      "tags": [],
-      "extensions": {
-        "github": "https://github.com/btspoony",
-        "telegram": "https://t.me/bt_wood",
-        "twitter": "https://x.com/btspoony",
-        "website": "https://btang.cn/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0xaa201615c0ecb331",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0xaa201615c0ecb331TBHB_Vault",
-        "receiver": "/public/FixsStandardFT_0xaa201615c0ecb331TBHB_Receiver",
-        "balance": "/public/FixsStandardFT_0xaa201615c0ecb331TBHB_Balance"
-      },
-      "flowAddress": "0xaa201615c0ecb331",
-      "symbol": "TBHB",
-      "name": "Bohao B",
-      "description": "No description",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/20SGVhZENpcm1721370737997",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0x0b3677727d6e6240",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x0b3677727d6e6240TBH_Vault",
-        "receiver": "/public/FixsStandardFT_0x0b3677727d6e6240TBH_Receiver",
-        "balance": "/public/FixsStandardFT_0x0b3677727d6e6240TBH_Balance"
-      },
-      "evmAddress": "0x6ef85d7fe35bc78e10d9b0e9eddc1728b7309cb5",
-      "flowAddress": "0x0b3677727d6e6240",
-      "symbol": "TBH",
-      "name": "Bohao Token",
-      "description": "No description",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/12SEVBRC5qcG1719913990511",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0x56d62b3bd3120e7a",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x56d62b3bd3120e7aTBH_Vault",
-        "receiver": "/public/FixsStandardFT_0x56d62b3bd3120e7aTBH_Receiver",
-        "balance": "/public/FixsStandardFT_0x56d62b3bd3120e7aTBH_Balance"
-      },
-      "flowAddress": "0x56d62b3bd3120e7a",
-      "symbol": "TBH",
-      "name": "Bohao Token",
-      "description": "Hey, buy me",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/12SEVBRC5qcG1720240024642",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0xed152c0ce12404b9",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0xed152c0ce12404b9RND_Vault",
-        "receiver": "/public/FixsStandardFT_0xed152c0ce12404b9RND_Receiver",
-        "balance": "/public/FixsStandardFT_0xed152c0ce12404b9RND_Balance"
-      },
-      "flowAddress": "0xed152c0ce12404b9",
-      "symbol": "RND",
-      "name": "Random Coin",
-      "description": "No description",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/16cmFuZG9tLn1720676670626",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0x33f74f3484dedeb3",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x33f74f3484dedeb3TBHC_Vault",
-        "receiver": "/public/FixsStandardFT_0x33f74f3484dedeb3TBHC_Receiver",
-        "balance": "/public/FixsStandardFT_0x33f74f3484dedeb3TBHC_Balance"
-      },
-      "flowAddress": "0x33f74f3484dedeb3",
-      "symbol": "TBHC",
-      "name": "Bohao C",
-      "description": "No description",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/20SGVhZENpcm1721373779639",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0x7baabb822a8bcbcf",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x7baabb822a8bcbcfCOIN_Vault",
-        "receiver": "/public/FixsStandardFT_0x7baabb822a8bcbcfCOIN_Receiver",
-        "balance": "/public/FixsStandardFT_0x7baabb822a8bcbcfCOIN_Balance"
-      },
-      "flowAddress": "0x7baabb822a8bcbcf",
-      "symbol": "COIN",
-      "name": "Coin Name",
-      "description": "Desc",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/24bG9nby01MT1720541688358",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0xf51d8ba3402fa785",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0xf51d8ba3402fa785EF_Vault",
-        "receiver": "/public/FixsStandardFT_0xf51d8ba3402fa785EF_Receiver",
-        "balance": "/public/FixsStandardFT_0xf51d8ba3402fa785EF_Balance"
-      },
-      "flowAddress": "0xf51d8ba3402fa785",
-      "symbol": "EF",
-      "name": "Eliza on Flow",
-      "description": "No description",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/28ZWxpemFPbk1736891575404",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0xeefce1c07809779e",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0xeefce1c07809779eTBHA_Vault",
-        "receiver": "/public/FixsStandardFT_0xeefce1c07809779eTBHA_Receiver",
-        "balance": "/public/FixsStandardFT_0xeefce1c07809779eTBHA_Balance"
-      },
-      "flowAddress": "0xeefce1c07809779e",
-      "symbol": "TBHA",
-      "name": "TBH Token A",
-      "description": "No description",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/12SEVBRC5qcG1721324284093",
-      "tags": [],
-      "extensions": {
-        "website": "https://linktr.ee/fixes.world/"
-      }
-    },
-    {
-      "chainId": 545,
-      "address": "0x0c2fe5a13b94795b",
-      "contractName": "FixesFungibleToken",
-      "path": {
-        "vault": "/storage/FixsStandardFT_0x0c2fe5a13b94795bTBHCC_Vault",
-        "receiver": "/public/FixsStandardFT_0x0c2fe5a13b94795bTBHCC_Receiver",
-        "balance": "/public/FixsStandardFT_0x0c2fe5a13b94795bTBHCC_Balance"
-      },
-      "flowAddress": "0x0c2fe5a13b94795b",
-      "symbol": "TBHCC",
-      "name": "Bohao Token CC",
-      "description": "No description",
-      "decimals": 8,
-      "logoURI": "https://static.fixes.world/20SGVhZENpcm1721968691021",
-      "tags": [],
-      "extensions": {
-        "twitter": "https://x.com/btspoony",
-        "website": "https://linktr.ee/fixes.world/"
+        "website": "https://flovatar.com",
+        "displaySource": "0xa51d7fe9e0080662",
+        "pathSource": "0xa51d7fe9e0080662"
       }
     },
     {
@@ -303,8 +57,6 @@
         "receiver": "/public/flowTokenReceiver",
         "balance": "/public/flowTokenBalance"
       },
-      "evmAddress": "0xd3bf53dac106a0290b0483ecbc89d40fcc961f3e",
-      "flowAddress": "0x7e60df042a9c0868",
       "symbol": "FLOW",
       "name": "Flow",
       "description": "",
@@ -314,10 +66,10 @@
         "utility-token"
       ],
       "extensions": {
-        "coingeckoId": "flow",
-        "github": "https://github.com/onflow/flow-core-contracts",
         "twitter": "https://twitter.com/flow_blockchain",
-        "discord": "https://discord.com/invite/J6fFnh2xx6",
+        "coingeckoId": "flow",
+        "discord": "http://discord.gg/flow",
+        "github": "https://github.com/onflow/flow-core-contracts",
         "documentation": "https://developers.flow.com/build/core-contracts/flow-token",
         "website": "https://flow.com",
         "displaySource": "0xa51d7fe9e0080662",
@@ -333,24 +85,40 @@
         "receiver": "/public/usdcFlowReceiver",
         "balance": "/public/usdcFlowMetadata"
       },
-      "flowAddress": "0x64adf39cbc354fcb",
       "symbol": "USDCf",
       "name": "USDC (Flow)",
       "description": "This fungible token representation of Axelar USDC is bridged from Flow EVM.",
       "decimals": 8,
-      "logoURI": "https://raw.githubusercontent.com/FlowFans/flow-token-list/main/token-registry/A.f1ab99c82dee3526.USDCFlow/USDCf.svg",
-      "tags": [
-        "stablecoin"
-      ],
+      "logoURI": "https://upload.wikimedia.org/wikipedia/commons/4/4a/Circle_USDC_Logo.svg",
+      "tags": [],
       "extensions": {
-        "website": "https://docs.axelar.dev/learn/axlusdc",
+        "website": "https://www.circle.com/",
         "displaySource": "0xa51d7fe9e0080662"
+      }
+    },
+    {
+      "chainId": 545,
+      "address": "0xe45c64ecfe31e465",
+      "contractName": "stFlowToken",
+      "path": {
+        "vault": "/storage/stFlowTokenVault",
+        "receiver": "/public/stFlowTokenReceiver",
+        "balance": "/public/stFlowTokenBalance"
+      },
+      "symbol": "stFlow",
+      "name": "Increment Staked FLOW",
+      "description": "stFlow is a liquid staking token representing the underlying staked flow position, allowing users to earn staking rewards and enjoy unlocked liquidity to participate in Flow's DeFi ecosystem at the same time.",
+      "decimals": 8,
+      "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.d6f80565193ad727.stFlowToken/logo.svg",
+      "tags": [],
+      "extensions": {
+        "website": "https://app.increment.fi/"
       }
     }
   ],
-  "totalAmount": 16,
+  "totalAmount": 5,
   "filterType": "ALL",
-  "timestamp": "2025-01-15T01:15:03.715Z",
+  "timestamp": "2024-05-13T06:34:36.510Z",
   "logoURI": "https://cdn.jsdelivr.net/gh/FlowFans/flow-token-list@main/token-registry/A.1654653399040a61.FlowToken/logo.svg",
   "keywords": [
     "Flow",
@@ -376,6 +144,10 @@
       "name": "wrapped-celer",
       "description": "Asset wrapped using celer bridge"
     },
+    "lp-token": {
+      "name": "lp-token",
+      "description": "Asset representing liquidity provider token"
+    },
     "utility-token": {
       "name": "utility-token",
       "description": "Tokens that are designed to be spent within a certain blockchain ecosystem"
@@ -391,7 +163,7 @@
   },
   "version": {
     "major": 1,
-    "minor": 1,
+    "minor": 0,
     "patch": 0
   }
 }


### PR DESCRIPTION
having contracts with the same name breaks the FRW-extension Cadence scripts, reverting back to the previous content